### PR TITLE
Bug fix. Shift coords first and then calculate intersection.

### DIFF
--- a/src/main/java/ru/yandex/qatools/ashot/coordinates/CoordsPreparationStrategy.java
+++ b/src/main/java/ru/yandex/qatools/ashot/coordinates/CoordsPreparationStrategy.java
@@ -28,8 +28,8 @@ public abstract class CoordsPreparationStrategy {
         return new CoordsPreparationStrategy() {
             @Override
             public Set<Coords> prepare(Collection<Coords> coordinates) {
-                return setReferenceCoords(screenshot.getOriginShift(),
-                        intersection(screenshot.getCoordsToCompare(), coordinates));
+                return intersection(screenshot.getCoordsToCompare(),
+                        setReferenceCoords(screenshot.getOriginShift(), new HashSet<>(coordinates)));
             }
         };
     }


### PR DESCRIPTION
**Bug summary:** Original (*i.e. not shifted*) coordinates were used when calculating intersection with modified coordsToCompare (*i.e. shifted*) in intersectingWith strategy in class CoordsPreparationStrategy.


**Actual:** Wrong order of operations 
1. calculate intersection of coordsToCompare and coordinates
2. setReferenceCoords - i.e. modify resulted intersection

The first operation returned empty set, because intersection was calculated on *shifted* coordsToCompare and *not_shifted* coordinates.


**Expected:** Correct order of operations
1. setReferenceCoords of coordinates - i.e. modify coordinates according to originShift
2. calculate intersection of coordsToCompare (*which are already shifted*) and coordinates
