### PR TITLE
ImageDiffer: don't create new extra BufferedImage if images are equal

### DIFF
--- a/src/main/java/ru/yandex/qatools/ashot/comparison/ImageDiff.java
+++ b/src/main/java/ru/yandex/qatools/ashot/comparison/ImageDiff.java
@@ -13,11 +13,8 @@ public class ImageDiff {
 
     private DiffMarkupPolicy diffMarkupPolicy;
 
-    public ImageDiff(BufferedImage expected, BufferedImage actual, DiffMarkupPolicy diffMarkupPolicy) {
+    public ImageDiff(DiffMarkupPolicy diffMarkupPolicy) {
         this.diffMarkupPolicy = diffMarkupPolicy;
-        int width = Math.max(expected.getWidth(), actual.getWidth());
-        int height = Math.max(expected.getHeight(), actual.getHeight());
-        this.diffMarkupPolicy.setDiffImage(new BufferedImage(width, height, actual.getType()));
     }
 
     private ImageDiff() {

--- a/src/main/java/ru/yandex/qatools/ashot/comparison/ImageDiffer.java
+++ b/src/main/java/ru/yandex/qatools/ashot/comparison/ImageDiffer.java
@@ -42,7 +42,7 @@ public class ImageDiffer {
     }
 
     public ImageDiff makeDiff(Screenshot expected, Screenshot actual) {
-        ImageDiff diff = new ImageDiff(expected.getImage(), actual.getImage(), diffMarkupPolicy);
+        ImageDiff diff = new ImageDiff(diffMarkupPolicy);
 
         if (areImagesEqual(expected, actual)) {
             diff.setDiffImage(actual.getImage());
@@ -60,8 +60,12 @@ public class ImageDiffer {
         CoordsSet compareCoordsSet = new CoordsSet(CoordsSet.union(actual.getCoordsToCompare(), expected.getCoordsToCompare()));
         CoordsSet ignoreCoordsSet = new CoordsSet(CoordsSet.intersection(actual.getIgnoredAreas(), expected.getIgnoredAreas()));
 
-        for (int i = 0; i < diff.getDiffImage().getWidth(); i++) {
-            for (int j = 0; j < diff.getDiffImage().getHeight(); j++) {
+        int width = Math.max(expected.getImage().getWidth(), actual.getImage().getWidth());
+        int height = Math.max(expected.getImage().getHeight(), actual.getImage().getHeight());
+        diff.setDiffImage(new BufferedImage(width, height, actual.getImage().getType()));
+
+        for (int i = 0; i < width; i++) {
+            for (int j = 0; j < height; j++) {
                 if (insideBothImages(i, j, expectedImageCoords, actualImageCoords)) {
                     if (!ignoreCoordsSet.contains(i, j)
                             && compareCoordsSet.contains(i, j)

--- a/src/main/java/ru/yandex/qatools/ashot/comparison/PointsMarkupPolicy.java
+++ b/src/main/java/ru/yandex/qatools/ashot/comparison/PointsMarkupPolicy.java
@@ -42,16 +42,6 @@ public class PointsMarkupPolicy extends DiffMarkupPolicy {
     }
 
     @Override
-    public BufferedImage getDiffImage() {
-        return diffImage;
-    }
-
-    @Override
-    public void setDiffImage(BufferedImage diffImage) {
-        this.diffImage = diffImage;
-    }
-
-    @Override
     public void addDiffPoint(int x, int y) {
         diffPoints.add(new Point(x, y));
     }


### PR DESCRIPTION
a slight optimize - do not create new BufferedImage in ImageDiff constructor, just in case expected and actual images are equal, instead use ImageDiff setter to set diff image