### PR TITLE
Drawing actual and expected images to diffImage before marking diff points

### DIFF
--- a/src/main/java/ru/yandex/qatools/ashot/comparison/DiffMarkupPolicy.java
+++ b/src/main/java/ru/yandex/qatools/ashot/comparison/DiffMarkupPolicy.java
@@ -45,10 +45,4 @@ public abstract class DiffMarkupPolicy {
         return diffImage;
     }
 
-    protected void fillTransparentAlpha(int width, int height, BufferedImage transparentImage) {
-        final Graphics2D graphics = transparentImage.createGraphics();
-        graphics.setComposite(AlphaComposite.Clear);
-        graphics.fillRect(0, 0, width, height);
-    }
-
 }

--- a/src/main/java/ru/yandex/qatools/ashot/comparison/ImageMarkupPolicy.java
+++ b/src/main/java/ru/yandex/qatools/ashot/comparison/ImageMarkupPolicy.java
@@ -20,8 +20,7 @@ public class ImageMarkupPolicy extends DiffMarkupPolicy {
     @Override
     public void setDiffImage(BufferedImage diffImage) {
         super.setDiffImage(diffImage);
-        transparentDiffImage = new BufferedImage(diffImage.getWidth(), diffImage.getHeight(), BufferedImage.TYPE_INT_ARGB);
-        fillTransparentAlpha(transparentDiffImage.getWidth(), transparentDiffImage.getHeight(), transparentDiffImage);
+        transparentDiffImage = new BufferedImage(diffImage.getWidth(), diffImage.getHeight(), BufferedImage.TYPE_INT_ARGB_PRE);
     }
 
     @Override

--- a/src/main/java/ru/yandex/qatools/ashot/comparison/PointsMarkupPolicy.java
+++ b/src/main/java/ru/yandex/qatools/ashot/comparison/PointsMarkupPolicy.java
@@ -34,8 +34,7 @@ public class PointsMarkupPolicy extends DiffMarkupPolicy {
         if (transparentMarkedImage == null) {
             int width = diffImage.getWidth();
             int height = diffImage.getHeight();
-            transparentMarkedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-            fillTransparentAlpha(width, height, transparentMarkedImage);
+            transparentMarkedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB_PRE);
             markDiffPoints(transparentMarkedImage);
         }
         return transparentMarkedImage;


### PR DESCRIPTION
Use Graphics.drawImage to paint pixels that are shared between two images.
Advantage of this method over older logic - it is quicker about 30%-50% for images with over 20% different pixels, it saves GC lots of cycles when limited memory.