### PR TITLE
safer ViewportPastingDecorator.getCurrentScrollY

### DIFF
--- a/src/main/java/ru/yandex/qatools/ashot/shooting/ViewportPastingDecorator.java
+++ b/src/main/java/ru/yandex/qatools/ashot/shooting/ViewportPastingDecorator.java
@@ -76,7 +76,8 @@ public class ViewportPastingDecorator extends ShootingDecorator {
     }
 
     protected int getCurrentScrollY(JavascriptExecutor js) {
-        return ((Number) js.executeScript("return window.scrollY;")).intValue();
+        return ((Number) js.executeScript("var scrY = window.scrollY;"
+        		+ "if(scrY){return scrY;} else {return 0;}")).intValue();
     }
 
     protected void scrollVertically(JavascriptExecutor js, int scrollY) {


### PR DESCRIPTION
On IE (tested on IE 11) when there's no scrollbar, "window.scrollY" returns undefined and this makes a NPE