### PR TITLE
Fixing squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/ru/yandex/qatools/ashot/Screenshot.java
+++ b/src/main/java/ru/yandex/qatools/ashot/Screenshot.java
@@ -36,17 +36,17 @@ public class Screenshot implements Serializable {
      */
     private Coords originShift = new Coords(0, 0);
 
+    public Screenshot(BufferedImage image) {
+        this.image = image;
+        this.coordsToCompare = new HashSet<>(asList(Coords.ofImage(image)));
+    }
+
     public BufferedImage getImage() {
         return image;
     }
 
     public void setImage(BufferedImage image) {
         this.image = image;
-    }
-
-    public Screenshot(BufferedImage image) {
-        this.image = image;
-        this.coordsToCompare = new HashSet<>(asList(Coords.ofImage(image)));
     }
 
     public Set<Coords> getCoordsToCompare() {

--- a/src/main/java/ru/yandex/qatools/ashot/coordinates/Coords.java
+++ b/src/main/java/ru/yandex/qatools/ashot/coordinates/Coords.java
@@ -14,80 +14,80 @@ import java.util.Set;
 
 public class Coords extends Rectangle {
 
-    public static Set<Coords> intersection(Collection<Coords> coordsPool1, Collection<Coords> coordsPool2) {
-        Set<Coords> intersectedCoords = new HashSet<>();
-        for (Coords coords1 : coordsPool1) {
-            for (Coords coords2 : coordsPool2) {
-                Coords intersection = coords1.intersection(coords2);
-                if (!intersection.isEmpty()) {
-                    intersectedCoords.add(intersection);
-                }
-            }
-        }
-        return intersectedCoords;
-    }
+	public Coords(Rectangle rectangle) {
+		super(rectangle);
+	}
 
-    public static Set<Coords> setReferenceCoords(Coords reference, Set<Coords> coordsSet) {
-        Set<Coords> referencedCoords = new HashSet<>();
-        for (Coords coords : coordsSet) {
-            referencedCoords.add(new Coords(
-                            coords.x - reference.x,
-                            coords.y - reference.y,
-                            coords.width,
-                            coords.height)
-            );
-        }
-        return referencedCoords;
-    }
+	public Coords(int x, int y, int width, int height) {
+		super(x, y, width, height);
+	}
 
-    public static Coords unity(Collection<Coords> coordsCollection) {
-        Coords unity = coordsCollection.iterator().next();
-        for (Coords coords : coordsCollection) {
-            unity = unity.union(coords);
-        }
-        return unity;
-    }
+	public Coords(int width, int height) {
+		super(width, height);
+	}
 
-    public static Coords ofImage(BufferedImage image) {
-        return new Coords(image.getWidth(), image.getHeight());
-    }
+	public static Set<Coords> intersection(Collection<Coords> coordsPool1, Collection<Coords> coordsPool2) {
+		Set<Coords> intersectedCoords = new HashSet<>();
+		for (Coords coords1 : coordsPool1) {
+			for (Coords coords2 : coordsPool2) {
+				Coords intersection = coords1.intersection(coords2);
+				if (!intersection.isEmpty()) {
+					intersectedCoords.add(intersection);
+				}
+			}
+		}
+		return intersectedCoords;
+	}
 
-    public Coords(Rectangle rectangle) {
-        super(rectangle);
-    }
+	public static Set<Coords> setReferenceCoords(Coords reference, Set<Coords> coordsSet) {
+		Set<Coords> referencedCoords = new HashSet<>();
+		for (Coords coords : coordsSet) {
+			referencedCoords.add(new Coords(
+					coords.x - reference.x,
+					coords.y - reference.y,
+					coords.width,
+					coords.height)
+					);
+		}
+		return referencedCoords;
+	}
 
-    public Coords(int x, int y, int width, int height) {
-        super(x, y, width, height);
-    }
+	public static Coords unity(Collection<Coords> coordsCollection) {
+		Coords unity = coordsCollection.iterator().next();
+		for (Coords coords : coordsCollection) {
+			unity = unity.union(coords);
+		}
+		return unity;
+	}
 
-    public Coords(int width, int height) {
-        super(width, height);
-    }
+	public static Coords ofImage(BufferedImage image) {
+		return new Coords(image.getWidth(), image.getHeight());
+	}
 
-    public void reduceBy(int pixels) {
-        if (pixels < getWidth() / 2 && pixels < getHeight() / 2) {
-            this.x += pixels;
-            this.y += pixels;
-            this.width -= pixels;
-            this.height -= pixels;
-        }
-    }
+	public void reduceBy(int pixels) {
+		if (pixels < getWidth() / 2 && pixels < getHeight() / 2) {
+			this.x += pixels;
+			this.y += pixels;
+			this.width -= pixels;
+			this.height -= pixels;
+		}
+	}
 
 
-    @SuppressWarnings("NullableProblems")
-    @Override
-    public Coords union(Rectangle r) {
-        return new Coords(super.union(r));
-    }
+	@SuppressWarnings("NullableProblems")
+	@Override
+	public Coords union(Rectangle r) {
+		return new Coords(super.union(r));
+	}
 
-    @SuppressWarnings("NullableProblems")
-    @Override
-    public Coords intersection(Rectangle r) {
-        return new Coords(super.intersection(r));
-    }
+	@SuppressWarnings("NullableProblems")
+	@Override
+	public Coords intersection(Rectangle r) {
+		return new Coords(super.intersection(r));
+	}
 
-    @Override
-    public String toString() {
-        return new Gson().toJson(this);
-    }
+	@Override
+	public String toString() {
+		return new Gson().toJson(this);
+	}
 }

--- a/src/test/java/ru/yandex/qatools/elementscompare/tests/DiffMarkupPolicyTest.java
+++ b/src/test/java/ru/yandex/qatools/elementscompare/tests/DiffMarkupPolicyTest.java
@@ -24,6 +24,12 @@ import static ru.yandex.qatools.elementscompare.tests.DifferTest.loadImage;
 
 @RunWith(Parameterized.class)
 public class DiffMarkupPolicyTest {
+	
+	private DiffMarkupPolicy diffMarkupPolicyA;
+	private DiffMarkupPolicy diffMarkupPolicyB;
+	    
+	@Parameterized.Parameter
+    public Class<? extends DiffMarkupPolicy> diffStorageClass;
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
@@ -32,12 +38,6 @@ public class DiffMarkupPolicyTest {
                 {ImageMarkupPolicy.class}
         });
     }
-
-    @Parameterized.Parameter
-    public Class<? extends DiffMarkupPolicy> diffStorageClass;
-
-    private DiffMarkupPolicy diffMarkupPolicyA;
-    private DiffMarkupPolicy diffMarkupPolicyB;
 
     @Before
     public void setUp() throws IllegalAccessException, InstantiationException {

--- a/src/test/java/ru/yandex/qatools/elementscompare/tests/DifferTest.java
+++ b/src/test/java/ru/yandex/qatools/elementscompare/tests/DifferTest.java
@@ -38,6 +38,9 @@ public class DifferTest {
     public static final BufferedImage IMAGE_IGNORED_PASS = loadImage("img/ignore_color_pass.png");
     public static final BufferedImage IMAGE_IGNORED_FAIL = loadImage("img/ignore_color_fail.png");
     public ImageDiffer imageDiffer;
+    
+    @Parameterized.Parameter
+    public Class<? extends DiffMarkupPolicy> diffStorageClass;
 
     public static BufferedImage loadImage(String path) {
         try {
@@ -54,9 +57,6 @@ public class DifferTest {
                 {ImageMarkupPolicy.class}
         });
     }
-
-    @Parameterized.Parameter
-    public Class<? extends DiffMarkupPolicy> diffStorageClass;
 
     @Before
     public void setUp() throws IllegalAccessException, InstantiationException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1213 -  The members of an interface declaration or class should appear in a pre-defined order". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1213


Please let me know if you have any questions.
Sameer Misger