### PR TITLE
Fixing squid:HiddenFieldCheck--Fixing squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/ru/yandex/qatools/ashot/AShot.java
+++ b/src/main/java/ru/yandex/qatools/ashot/AShot.java
@@ -115,8 +115,8 @@ public class AShot implements Serializable {
         Set<Coords> elementCoords = coordsProvider.ofElements(driver, elements);
         BufferedImage shot = shootingStrategy.getScreenshot(driver, elementCoords);
         Screenshot screenshot = cropper.crop(shot, shootingStrategy.prepareCoords(elementCoords));
-        Set<Coords> ignoredAreas = compileIgnoredAreas(driver, intersectingWith(screenshot));
-        screenshot.setIgnoredAreas(shootingStrategy.prepareCoords(ignoredAreas));
+        Set<Coords> ignoredAreasLocal = compileIgnoredAreas(driver, intersectingWith(screenshot));
+        screenshot.setIgnoredAreas(shootingStrategy.prepareCoords(ignoredAreasLocal));
         return screenshot;
     }
 

--- a/src/main/java/ru/yandex/qatools/ashot/util/ImageTool.java
+++ b/src/main/java/ru/yandex/qatools/ashot/util/ImageTool.java
@@ -39,10 +39,10 @@ public final class ImageTool {
         if (inaccuracy == 0) return rgb1 == rgb2;
         int red1 = (rgb1 & 0x00FF0000) >> 16;
         int green1 = (rgb1 & 0x0000FF00) >> 8;
-        int blue1 = (rgb1 & 0x000000FF);
+        int blue1 = rgb1 & 0x000000FF;
         int red2 = (rgb2 & 0x00FF0000) >> 16;
         int green2 = (rgb2 & 0x0000FF00) >> 8;
-        int blue2 = (rgb2 & 0x000000FF);
+        int blue2 = rgb2 & 0x000000FF;
         return Math.abs(red1 - red2) <= inaccuracy &&
                 Math.abs(green1 - green2) <= inaccuracy &&
                 Math.abs(blue1 - blue2) <= inaccuracy;

--- a/src/test/java/ru/yandex/qatools/ashot/shooting/VerticalPastingShootingStrategyTest.java
+++ b/src/test/java/ru/yandex/qatools/ashot/shooting/VerticalPastingShootingStrategyTest.java
@@ -44,10 +44,10 @@ public class VerticalPastingShootingStrategyTest {
     @Before
     public void setUp() throws Exception {
         coordsSet = new HashSet<>();
-        MockVerticalPastingShootingDecorator shootingStrategy =
+        MockVerticalPastingShootingDecorator shootingStrategyLocal =
                 new MockVerticalPastingShootingDecorator(new SimpleShootingStrategy());
-        shootingStrategy.withScrollTimeout(0);
-        this.shootingStrategy = spy(shootingStrategy);
+        shootingStrategyLocal.withScrollTimeout(0);
+        this.shootingStrategy = spy(shootingStrategyLocal);
         when(((TakesScreenshot) wd).getScreenshotAs(any(OutputType.class))).thenReturn(getImageAsBytes());
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " squid:HiddenFieldCheck-- Local variables should not shadow class field, squid:UselessParenthesesCheck-- Useless parentheses around expressions should be removed to prevent any misunderstanding" information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck


Please let me know if you have any questions.
Sameer Misger