### PR TITLE
Use hamcrest-core instead of hamcrest-all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest-core</artifactId>
             <version>1.3</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
'hamcrest-all' dependency is excessive for aShot. It includes all classes
of all hamcrest jars (see more details:
https://code.google.com/archive/p/hamcrest/wikis/HamcrestDistributables.wiki).
For now 'hamcrest-core' should be enough.