### PR TITLE
Use latest avaialble dependencies, reduce dependency scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,18 @@
     <dependencies>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <version>2.47.2</version>
+            <artifactId>selenium-remote-driver</artifactId>
+            <version>2.53.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -71,13 +76,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.8.4</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
 - Change 'selenium-java' to 'selenium-remote-driver' ('selenium-java' has a lot of unused transitive dependencies)
 - Add commons-io (2.5) explicitly (it was transitive previously)
 - Update Selenium from 2.47.2 to 2.53.0
 - Update Gson from 2.2.4 to 2.6.2
 - Update test dependencies: JUnit 4.11 -> 4.12, Mockito 1.8.4 -> 1.10.19