### PR TITLE
Only augment WebDriver if necessary

### DIFF
--- a/src/main/java/ru/yandex/qatools/ashot/shooting/SimpleShootingStrategy.java
+++ b/src/main/java/ru/yandex/qatools/ashot/shooting/SimpleShootingStrategy.java
@@ -7,11 +7,11 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Augmenter;
 import ru.yandex.qatools.ashot.coordinates.Coords;
 
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Set;
+import javax.imageio.ImageIO;
 
 /**
  * Gets screenshot from webdriver.
@@ -21,7 +21,12 @@ public class SimpleShootingStrategy implements ShootingStrategy {
     @Override
     public BufferedImage getScreenshot(WebDriver wd) {
         ByteArrayInputStream imageArrayStream = null;
-        TakesScreenshot takesScreenshot = (TakesScreenshot) new Augmenter().augment(wd);
+        TakesScreenshot takesScreenshot;
+        try {
+            takesScreenshot = (TakesScreenshot) wd;
+        } catch (ClassCastException ignored){
+            takesScreenshot = (TakesScreenshot) new Augmenter().augment(wd);
+        }
         try {
             imageArrayStream = new ByteArrayInputStream(takesScreenshot.getScreenshotAs(OutputType.BYTES));
             return ImageIO.read(imageArrayStream);

--- a/src/main/java/ru/yandex/qatools/ashot/shooting/SimpleShootingStrategy.java
+++ b/src/main/java/ru/yandex/qatools/ashot/shooting/SimpleShootingStrategy.java
@@ -7,11 +7,11 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Augmenter;
 import ru.yandex.qatools.ashot.coordinates.Coords;
 
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Set;
-import javax.imageio.ImageIO;
 
 /**
  * Gets screenshot from webdriver.


### PR DESCRIPTION
When using Selenium 3.3 on grid, AShot was causing ExceptionInInitializerErrors.

I was able to reproduce this exception outside of AShot with repeated calls to `new Augmenter().augment(wd)`. 

AShot was working on local webdriver instances but not on grid RemoteWebDrivers. Nowhere in my test code am I calling `Augmenter`. Unfortunately there's no way I was able to find to test if a WebDriver is already augmented. 

I hate try/catch as flow control but this solution works very stably and quickly for me.